### PR TITLE
[Feat] 런팟 연결기 구현

### DIFF
--- a/app/utils/runpod_connector.py
+++ b/app/utils/runpod_connector.py
@@ -1,0 +1,84 @@
+import os
+import requests
+from typing import Dict, Optional
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# RunPod API 설정
+RUNPOD_IP = os.getenv("RUNPOD_IP")
+RUNPOD_PORT = os.getenv("RUNPOD_PORT")
+RUNPOD_API_KEY = os.getenv("RUNPOD_API_KEY")
+
+RUNPOD_API_URL = f"http://{RUNPOD_IP}:{RUNPOD_PORT}/v1/chat/completions"
+_session = requests.Session()
+
+
+def call_runpod(
+    payload: Dict,
+    headers: Optional[Dict] = None,
+    timeout: int = 30
+) -> Optional[str]:
+    """
+    Runpod API에 요청을 보냅니다.
+    
+    Args:
+        payload: 요청 본문 데이터 (model, messages, params 등)
+        headers: 추가 헤더 (기본적으로 Authorization 헤더는 자동 추가됨)
+        timeout: 요청 타임아웃 (기본값 30초)
+    
+    Returns:
+        응답 텍스트 (content) 또는 None
+    """
+    try:
+        # 기본 헤더 설정
+        default_headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {RUNPOD_API_KEY}"
+        }
+        
+        # 사용자 정의 헤더가 있다면 병합 (사용자 정의가 우선)
+        if headers:
+            default_headers.update(headers)
+            
+        response = _session.post(
+            RUNPOD_API_URL, 
+            json=payload, 
+            headers=default_headers, 
+            timeout=timeout
+        )
+        
+        if response.status_code != 200:
+            print(f"[RunPod] API 오류 ({response.status_code}): {response.text}")
+            return None
+        
+        result = response.json()
+        
+        try:
+            output = result['choices'][0]['message']['content'].strip()
+            return output
+        except (KeyError, IndexError):
+            print(f"[RunPod] 응답 구조가 예상과 다릅니다: {result}")
+            return None
+            
+    except requests.exceptions.RequestException as e:
+        print(f"[RunPod] 네트워크 오류: {e}")
+        return None
+    except Exception as e:
+        print(f"[RunPod] 처리 중 문제 발생: {e}")
+        import traceback
+        traceback.print_exc()
+        return None
+
+
+def get_runpod_status() -> Dict[str, any]:
+    """
+    Runpod 연결 상태를 반환합니다.
+    
+    Returns:
+        연결 상태 정보 딕셔너리
+    """
+    return {
+        "api_url": RUNPOD_API_URL,
+        "configured": all([RUNPOD_IP, RUNPOD_PORT, RUNPOD_API_KEY])
+    }


### PR DESCRIPTION
### What to do

- [x] 런팟에 연결하여 응답을 받아오는 `call_runpod` 함수
- [x] [디버깅용] 연결 상태를 반환하는 `get_runpod_status` 함수

### Description

1. 환경변수로부터 런팟 ip, port, key를 로드
2. 런팟이 사용되는 모듈에서 `call_runpod()` 호출
    해당 함수는 다음 파라미터를 받습니다.
  - payload: 요청할 데이터
  - headers: 반환 타입과 key 정의 (넘겨주지 않을 시 기본값 json)
  - timeout: 기다릴 시간 (기본값 30s)
3. 런팟 서버에 요청을 보내 response를 수신
  -요청을 최초 1회만 보내면 서버가 유지되는 한 재연결이 필요없도록 `requests.Session()` 사용
4. response로부터 `['choices'][0]['message']['content']`으로 필터링하여 온전히 본문만 가져오도록 정제
5. 정제된 본문 반환

### Test

일단 텍스트 교정 코드로 테스트했기 때문에 tests/sllm_refine/test_refiner.py로 확인 가능합니다.

### References

`get_runpod_status` 호출 시 다음과 같이 출력되어야 합니다.
  - api_url: 연결된 런팟 IP
  - configured: 설정값들이 온전히 로드되었는지 여부
`{'api_url': 'http://213.192.2.84:40197/v1/chat/completions', 'configured': True}`