### PR TITLE
[deploy] Ci health rollback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ["main", "deploy"]
+
+jobs:
+  lint_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Syntax Check
+        run: |
+          python -m compileall -q app tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           port: ${{ secrets.EC2_PORT }}
+          command_timeout: 60m
           script: |
             set -euo pipefail
             cd /opt/callact-backend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,3 +42,16 @@ jobs:
             sudo docker compose -f docker-compose.prod.yml -f docker-compose.prod.override.yml up -d --build
             sudo docker image prune -f
             sudo docker builder prune -af || true
+
+            # Post-deploy health check (retry for up to ~60s)
+            for i in $(seq 1 12); do
+              if curl -fsS http://127.0.0.1/nginx-health >/dev/null && \
+                 curl -fsS http://127.0.0.1/api/v1/health >/dev/null; then
+                echo "Health check OK"
+                exit 0
+              fi
+              echo "Health check retry $i/12..."
+              sleep 5
+            done
+            echo "Health check FAILED"
+            exit 1

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,35 @@
+# Deployment Runbook
+
+## Triggers
+- **CI (PR)**: runs syntax check on pull requests to `main`/`deploy`.
+- **CD (push)**: deploys automatically on push/merge to `main`.
+
+## Secrets (GitHub Actions)
+- `EC2_HOST`, `EC2_USER`, `EC2_SSH_KEY`, `EC2_PORT`
+
+## Deploy Flow (CD)
+1. GitHub Actions SSH into EC2.
+2. `git reset --hard origin/main`
+3. `docker compose up -d --build`
+4. Health check:
+   - `http://127.0.0.1/nginx-health`
+   - `http://127.0.0.1/api/v1/health`
+
+## Rollback (Manual)
+Use either option below.
+
+### Option A) Roll back to a known commit
+```bash
+cd /opt/callact-backend
+git fetch --all
+git reset --hard <commit_sha>
+sudo docker compose -f docker-compose.prod.yml -f docker-compose.prod.override.yml up -d --build
+```
+
+### Option B) Revert via PR
+1. Create a PR that reverts the bad commit(s).
+2. Merge to `main` (CD will deploy automatically).
+
+## Notes
+- `.env.prod` is untracked and stays on the server during deploys.
+- EC2 must allow SSH (port 22) from GitHub Actions to run CD.


### PR DESCRIPTION

### Description

1. **배포 후 Health check 추가**  
   - `nginx-health` / `api/v1/health` 확인, 실패 시 Actions 실패 처리

2. **CI 분리 (PR 전용)**  
   - PR에는 `compileall` 문법 체크만 수행

3. **롤백/배포 문서 추가**  
   - `docs/DEPLOYMENT.md`에 배포/롤백 방법 기록

4. **배포 타임아웃 확장**  
   - `command_timeout: 60m` 설정 추가 (pip 설치가 오래 걸릴 때 대비)


